### PR TITLE
Bugfix for single loader case

### DIFF
--- a/torch_cka/cka.py
+++ b/torch_cka/cka.py
@@ -143,7 +143,10 @@ class CKA:
 
         if dataloader2 is None:
             warn("Dataloader for Model 2 is not given. Using the same dataloader for both models.")
-            dataloader2 = dataloader1
+            dataloader2 = dataloader1 #for convenience in the code
+            same_loader = True
+        else:
+            same_loader = False
 
         self.model1_info['Dataset'] = dataloader1.dataset.__repr__().split('\n')[0]
         self.model2_info['Dataset'] = dataloader2.dataset.__repr__().split('\n')[0]
@@ -153,9 +156,14 @@ class CKA:
 
         self.hsic_matrix = torch.zeros(N, M, 3)
 
-        num_batches = min(len(dataloader1), len(dataloader1))
+        num_batches = min(len(dataloader1), len(dataloader2))
 
-        for (x1, *_), (x2, *_) in tqdm(zip(dataloader1, dataloader2), desc="| Comparing features |", total=num_batches):
+        for item in tqdm(dataloader1 if same_loader else zip(dataloader1, dataloader2), desc="| Comparing features |", total=num_batches):
+            if same_loader:
+                (x, *_) = item
+                x1 = x2 = x
+            else:
+                (x1, *_), (x2, *_) = item
 
             self.model1_features = {}
             self.model2_features = {}


### PR DESCRIPTION
Hi,

Thanks for the clean repo.
I ran a sanity check with giving the exact replica of the same model, expecting to get an identity diagonal for the output of `plot_results()`, but it wasn't the case.

After looking at the code, I noticed that there is a line that the case that `dataloader2` is not given has some issues. As it creates a reference copy of `dataloader1` and hence, when zipped together in the loop, same loader is being used for getting `x1` and `x2`, so they would be different indices of the dataset, resulting in different samples.

Looking forward to hearing from you!
Best. 